### PR TITLE
Load HPCBio version of functions

### DIFF
--- a/R/graphical_methods.R
+++ b/R/graphical_methods.R
@@ -442,6 +442,8 @@ ggformat <- function(physeq, taxaRank1 = "Phylum", taxaSet1 = "Proteobacteria",
     tax <- as(tax_table(physeq), "matrix")
     tax[is.na(tax)] <- "Unknown"
     tax[tax %in% c("", "unclassified", "Unclassified", "NA")] <- "Unknown"
+    tax[grepl("uncultured", tax, ignore.case = TRUE)] <- "Unknown"
+    tax[grepl("metagenome", tax, ignore.case = TRUE)] <- "Unknown"
     tax <- data.frame(OTU = rownames(tax), tax)
     mdf <- merge(mdf, tax, by.x = "OTU")
     ## Aggregate by taxaRank2

--- a/R/load-extra-functions.R
+++ b/R/load-extra-functions.R
@@ -16,7 +16,7 @@ scripts <- c("graphical_methods.R",
              "import_frogs.R",
              "prevalence.R",
              "compute_niche.R")
-urls <- paste0("https://raw.githubusercontent.com/mahendra-mariadassou/phyloseq-extended/master/R/", scripts)
+urls <- paste0("https://raw.githubusercontent.com/HPCBio/phyloseq-extended/master/R/", scripts)
 
 for (url in urls) {
   source(url)


### PR DESCRIPTION
This will probably break my code in https://github.com/HPCBio/godoy-2020Aug-16S, but I noticed in the process of using this repo that I was actually using the `mahendra-mariadassou` version rather than the `HPCBio` version (based on the args of `ggformat`).  This change fixes that.